### PR TITLE
Remove separate typehint repo

### DIFF
--- a/docs/APIVersion.md
+++ b/docs/APIVersion.md
@@ -1,0 +1,7 @@
+# API Version
+
+Stripe has two relevant notions of API version: the version configured on your Stripe account, and the version used by the installed `stripe` Python package. For consistency we refer to these as the `AccountVersion` and the `LibraryVersion`, respectively.
+
+Webhook notifications from Stripe to your application will use the `AccountVersion`. Requests made through the local library use the `LibraryVersion`, which is determined by the installed `stripe` package. If you keep stripe unpinned, that will usually mean the latest library-supported version. This model is intuitive for outbound calls: if your local function calls typecheck and validate against the installed library, Stripe will accept that request shape on the remote end.
+
+Receiving data is trickier, because inbound payloads may arrive in a shape that the local `stripe` package no longer models or validates. We address that by shipping our own [models](./Static-Analysis.md), which preserve older Stripe versions for analysis and validation. For _outbound_ requests, though, we defer to the installed Stripe library defaults, so pushed data follows the `LibraryVersion` rather than the `AccountVersion`.

--- a/integration-runner/uv.lock
+++ b/integration-runner/uv.lock
@@ -1279,7 +1279,6 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23.5" },
     { name = "ruff", specifier = ">=0.2.1" },
     { name = "ty", specifier = ">=0.0.1a17" },
-    { name = "types-stripe", specifier = ">=3.5.2.20240106" },
 ]
 
 [[package]]

--- a/mountaineer_billing/__tests__/daemons/test_reload_stripe_object.py
+++ b/mountaineer_billing/__tests__/daemons/test_reload_stripe_object.py
@@ -173,6 +173,51 @@ def build_invoice_payload() -> tuple[InvoiceModel, str | None]:
     )
 
 
+def build_upcoming_invoice_payload() -> tuple[InvoiceModel, str | None]:
+    customer_id = "cus_upcoming_invoice"
+    return (
+        InvoiceModel(
+            object="invoice",
+            id=None,
+            amount_due=100,
+            amount_overpaid=0,
+            amount_paid=0,
+            amount_remaining=100,
+            amount_shipping=0,
+            attempt_count=0,
+            attempted=False,
+            auto_advance=False,
+            automatic_tax={"enabled": False},
+            billing_reason="upcoming",
+            collection_method="charge_automatically",
+            created=1,
+            currency="usd",
+            customer=customer_id,
+            default_tax_rates=[],
+            discounts=[],
+            issuer={"type": "self"},
+            lines={
+                "object": "list",
+                "data": [],
+                "has_more": False,
+                "url": "/v1/invoices/upcoming_in_test/lines",
+            },
+            livemode=False,
+            payment_settings={"payment_method_options": {}},
+            period_end=2,
+            period_start=1,
+            post_payment_credit_notes_amount=0,
+            pre_payment_credit_notes_amount=0,
+            starting_balance=0,
+            status="draft",
+            status_transitions={},
+            subtotal=100,
+            total=100,
+        ),
+        customer_id,
+    )
+
+
 def build_payment_intent_payload() -> tuple[PaymentIntent, str | None]:
     customer_id = "cus_payment_intent"
     return (
@@ -415,6 +460,46 @@ async def test_reload_stripe_object_workflow_ignores_unsupported_payload(
         event_id=event_id,
         stripe_event_id="evt_payment_method",
         stripe_object_id="evt_payment_method",
+        object_type="unsupported",
+        stripe_customer_id=None,
+    )
+    assert await db_connection.exec(select(models.StripeObject)) == []
+
+
+@pytest.mark.asyncio
+async def test_reload_stripe_object_workflow_ignores_upcoming_invoice_preview(
+    db_connection: DBConnection,
+) -> None:
+    invoice_model, customer_id = build_upcoming_invoice_payload()
+    event_id = uuid4()
+    event_model = build_event_model(
+        event_id="evt_invoice_upcoming",
+        event_type="invoice.upcoming",
+        object_model=invoice_model,
+    )
+
+    await db_connection.insert(
+        [
+            models.StripeEvent(
+                id=event_id,
+                stripe_event_id=event_model.id,
+                stripe_event_type=event_model.type,
+                stripe_object_id=None,
+                stripe_object_type="invoice",
+                stripe_customer_id=customer_id,
+                livemode=False,
+                stripe_created_at=datetime.now(timezone.utc),
+                payload=event_model.model_dump(mode="json"),
+            )
+        ]
+    )
+
+    response = await ReloadStripeObject().run(event_id=event_id)
+
+    assert response == ReloadStripeObjectResponse(
+        event_id=event_id,
+        stripe_event_id="evt_invoice_upcoming",
+        stripe_object_id="evt_invoice_upcoming",
         object_type="unsupported",
         stripe_customer_id=None,
     )

--- a/mountaineer_billing/__tests__/daemons/test_reload_stripe_object.py
+++ b/mountaineer_billing/__tests__/daemons/test_reload_stripe_object.py
@@ -486,9 +486,7 @@ async def test_reload_stripe_object_workflow_ignores_upcoming_invoice_preview(
     db_connection: DBConnection,
     invoice_id: str | None,
 ) -> None:
-    invoice_payload, customer_id = build_upcoming_invoice_payload(
-        invoice_id=invoice_id
-    )
+    invoice_payload, customer_id = build_upcoming_invoice_payload(invoice_id=invoice_id)
     event_id = uuid4()
     event_model = build_event_model(
         event_id="evt_invoice_upcoming",

--- a/mountaineer_billing/__tests__/daemons/test_reload_stripe_object.py
+++ b/mountaineer_billing/__tests__/daemons/test_reload_stripe_object.py
@@ -173,49 +173,51 @@ def build_invoice_payload() -> tuple[InvoiceModel, str | None]:
     )
 
 
-def build_upcoming_invoice_payload() -> tuple[InvoiceModel, str | None]:
+def build_upcoming_invoice_payload(
+    *,
+    invoice_id: str | None,
+) -> tuple[dict[str, object], str | None]:
     customer_id = "cus_upcoming_invoice"
-    return (
-        InvoiceModel(
-            object="invoice",
-            id=None,
-            amount_due=100,
-            amount_overpaid=0,
-            amount_paid=0,
-            amount_remaining=100,
-            amount_shipping=0,
-            attempt_count=0,
-            attempted=False,
-            auto_advance=False,
-            automatic_tax={"enabled": False},
-            billing_reason="upcoming",
-            collection_method="charge_automatically",
-            created=1,
-            currency="usd",
-            customer=customer_id,
-            default_tax_rates=[],
-            discounts=[],
-            issuer={"type": "self"},
-            lines={
-                "object": "list",
-                "data": [],
-                "has_more": False,
-                "url": "/v1/invoices/upcoming_in_test/lines",
-            },
-            livemode=False,
-            payment_settings={"payment_method_options": {}},
-            period_end=2,
-            period_start=1,
-            post_payment_credit_notes_amount=0,
-            pre_payment_credit_notes_amount=0,
-            starting_balance=0,
-            status="draft",
-            status_transitions={},
-            subtotal=100,
-            total=100,
-        ),
-        customer_id,
-    )
+    payload: dict[str, object] = {
+        "object": "invoice",
+        "amount_due": 100,
+        "amount_overpaid": 0,
+        "amount_paid": 0,
+        "amount_remaining": 100,
+        "amount_shipping": 0,
+        "attempt_count": 0,
+        "attempted": False,
+        "auto_advance": False,
+        "automatic_tax": {"enabled": False},
+        "billing_reason": "upcoming",
+        "collection_method": "charge_automatically",
+        "created": 1,
+        "currency": "usd",
+        "customer": customer_id,
+        "default_tax_rates": [],
+        "discounts": [],
+        "issuer": {"type": "self"},
+        "lines": {
+            "object": "list",
+            "data": [],
+            "has_more": False,
+            "url": "/v1/invoices/upcoming_in_test/lines",
+        },
+        "livemode": False,
+        "payment_settings": {"payment_method_options": {}},
+        "period_end": 2,
+        "period_start": 1,
+        "post_payment_credit_notes_amount": 0,
+        "pre_payment_credit_notes_amount": 0,
+        "starting_balance": 0,
+        "status": "draft",
+        "status_transitions": {},
+        "subtotal": 100,
+        "total": 100,
+    }
+    if invoice_id is not None:
+        payload["id"] = invoice_id
+    return payload, customer_id
 
 
 def build_payment_intent_payload() -> tuple[PaymentIntent, str | None]:
@@ -304,15 +306,20 @@ def build_event_model(
     *,
     event_id: str,
     event_type: str,
-    object_model: BaseModel,
+    object_model: BaseModel | dict[str, object],
 ) -> Event:
+    object_payload = (
+        object_model.model_dump(mode="json")
+        if isinstance(object_model, BaseModel)
+        else object_model
+    )
     return Event(
         id=event_id,
         object="event",
         api_version=API_VERSION,
         created=1,
         data={
-            "object": object_model.model_dump(mode="json"),
+            "object": object_payload,
         },
         livemode=False,
         pending_webhooks=0,
@@ -467,15 +474,26 @@ async def test_reload_stripe_object_workflow_ignores_unsupported_payload(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("invoice_id",),
+    [
+        (None,),
+        ("upcoming_in_test",),
+    ],
+    ids=["missing_id", "with_id"],
+)
 async def test_reload_stripe_object_workflow_ignores_upcoming_invoice_preview(
     db_connection: DBConnection,
+    invoice_id: str | None,
 ) -> None:
-    invoice_model, customer_id = build_upcoming_invoice_payload()
+    invoice_payload, customer_id = build_upcoming_invoice_payload(
+        invoice_id=invoice_id
+    )
     event_id = uuid4()
     event_model = build_event_model(
         event_id="evt_invoice_upcoming",
         event_type="invoice.upcoming",
-        object_model=invoice_model,
+        object_model=invoice_payload,
     )
 
     await db_connection.insert(

--- a/mountaineer_billing/daemons/reload_stripe_object.py
+++ b/mountaineer_billing/daemons/reload_stripe_object.py
@@ -181,6 +181,27 @@ def extract_internal_user_id(payload: dict[str, Any]) -> UUID | None:
     return None
 
 
+def should_skip_typed_object_hydration(
+    *,
+    event_type: str | None,
+    object_type: Any,
+    stripe_object_payload: dict[str, Any],
+) -> bool:
+    """
+    Allow preview invoices without ids to stay in the audit log.
+
+    Stripe can emit ``invoice.upcoming`` previews without a canonical invoice id.
+    Those payloads should still be loadable from ``StripeEvent``, but they cannot
+    be re-hydrated into the generated ``InvoiceModel`` for newer API versions.
+    """
+
+    return (
+        object_type == "invoice"
+        and event_type == "invoice.upcoming"
+        and not isinstance(stripe_object_payload.get("id"), str)
+    )
+
+
 class ReloadStripeObjectPayload(BaseModel):
     event: StripeEventPayload
     charge: StripeChargePayload = None
@@ -362,12 +383,17 @@ async def load_saved_stripe_event(
     stripe_object_payload = stripe_object_to_dict(stripe_object)
     object_type = stripe_object_payload.get("object")
     api_version = saved_event.payload.get("api_version")
+    event_type = saved_event.payload.get("type")
 
     payload_kwargs: dict[str, Any] = {
         "event": saved_event.typed_payload,
     }
 
-    if object_type in OBJECT_TYPE_TO_ADAPTER:
+    if object_type in OBJECT_TYPE_TO_ADAPTER and not should_skip_typed_object_hydration(
+        event_type=event_type,
+        object_type=object_type,
+        stripe_object_payload=stripe_object_payload,
+    ):
         adapter = OBJECT_TYPE_TO_ADAPTER[object_type]
         field_name = OBJECT_TYPE_TO_FIELD[object_type]
         payload_kwargs[field_name] = adapter.validate_python(

--- a/mountaineer_billing/daemons/reload_stripe_object.py
+++ b/mountaineer_billing/daemons/reload_stripe_object.py
@@ -286,11 +286,21 @@ class ReloadStripeObject(Workflow):
                 timeout=timedelta(seconds=30),
             )
         elif hydrated_event.payload.invoice is not None:
-            reloaded_object = await self.run_action(
-                reload_invoice(hydrated_event),
-                retry=RetryPolicy(attempts=3, backoff_seconds=5),
-                timeout=timedelta(seconds=30),
-            )
+            # `invoice.upcoming` carries a preview invoice, not a canonical invoice
+            # snapshot. Those payloads can omit `id`, so keep the webhook in the
+            # StripeEvent audit log but do not mirror it into StripeObject.
+            if hydrated_event.payload.event.type == "invoice.upcoming":
+                reloaded_object = await self.run_action(
+                    ignore_unsupported_stripe_payload(hydrated_event),
+                    retry=RetryPolicy(attempts=3, backoff_seconds=5),
+                    timeout=timedelta(seconds=30),
+                )
+            else:
+                reloaded_object = await self.run_action(
+                    reload_invoice(hydrated_event),
+                    retry=RetryPolicy(attempts=3, backoff_seconds=5),
+                    timeout=timedelta(seconds=30),
+                )
         elif hydrated_event.payload.payment_intent is not None:
             reloaded_object = await self.run_action(
                 reload_payment_intent(hydrated_event),

--- a/mountaineer_billing/dependencies/stripe.py
+++ b/mountaineer_billing/dependencies/stripe.py
@@ -90,7 +90,7 @@ def customer_session_authorization(
         ),
     ):
         # @pierce 03/01/2024: CustomerSession is not provided in the typeshed definitions for stripe
-        customer_session = stripe.CustomerSession.create(  # type: ignore
+        customer_session = stripe.CustomerSession.create(
             customer=stripe_customer_id,
             # Enabled components always follow the same syntax
             components={

--- a/mountaineer_billing/webhook.py
+++ b/mountaineer_billing/webhook.py
@@ -1,11 +1,12 @@
 from collections.abc import Mapping
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 import stripe
 from fastapi import APIRouter, Depends, Request
 from iceaxe import DBConnection
 from iceaxe.mountaineer import DatabaseDependencies
+from stripe import SignatureVerificationError
 
 from mountaineer import CoreDependencies
 
@@ -18,16 +19,6 @@ from mountaineer_billing.daemons.reload_stripe_object import (
     to_datetime,
 )
 from mountaineer_billing.logging import LOGGER
-
-if TYPE_CHECKING:
-    # More recent versions of stripe have refactored errors to be importable
-    # from the main `stripe` package and throw a warning if we try to import from
-    # the deprecated `stripe.error` package. However our typeshed definitions don't
-    # expose errors from the main package, so we need to import from the deprecated
-    # package.
-    from stripe.error import SignatureVerificationError
-else:
-    from stripe import SignatureVerificationError
 
 router = APIRouter(prefix="/external/billing")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dev = [
     "ruff>=0.2.1",
     "ty>=0.0.1a17",
     "pytest>=8.0.0",
-    "types-stripe>=3.5.2.20240106",
     "pytest-asyncio>=0.23.5",
     "freezegun>=1.5.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1189,7 +1189,6 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "ty" },
-    { name = "types-stripe" },
 ]
 
 [package.metadata]
@@ -1210,7 +1209,6 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23.5" },
     { name = "ruff", specifier = ">=0.2.1" },
     { name = "ty", specifier = ">=0.0.1a17" },
-    { name = "types-stripe", specifier = ">=3.5.2.20240106" },
 ]
 
 [[package]]
@@ -1892,15 +1890,15 @@ wheels = [
 
 [[package]]
 name = "stripe"
-version = "15.0.0"
+version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/5a/0cdea4b7911b8012936c765544109da27c0728f6911ec7aefe9d59e7a4f9/stripe-15.0.0.tar.gz", hash = "sha256:0717cd9ba8e8193cef8b1c488ce27836754df496ab6fb75864096e0cdf15e52d", size = 1486873, upload-time = "2026-03-26T01:39:04.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/b4/bd4baf56cfb9ec7ee66b0d33611e196afaabd12ddcc2322f29449649ec5f/stripe-15.0.1.tar.gz", hash = "sha256:3c04e8cc9ec8d9542f9dd998e2a4361dbe3d0b6150ca17d3f352546cf22c5565", size = 1490326, upload-time = "2026-04-01T23:52:21.218Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/4a/4431c998c451cf07f8b4fed98f425b4aaf3d59cc4fb1e6f54d7713606688/stripe-15.0.0-py3-none-any.whl", hash = "sha256:434ec5267a7402a30b76786d159c18d0e138f89195969d6c56bea2e08d353be0", size = 2125454, upload-time = "2026-03-26T01:39:01.801Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/ee/4537ba64d6c2f8bc58667f4381429c804bbc2e854b5857337cbc39add620/stripe-15.0.1-py3-none-any.whl", hash = "sha256:0a525e4550b5bf7fb44ff682266b9d46cfb38dd6f1f97a85d361c452f69e6b4b", size = 2132160, upload-time = "2026-04-01T23:52:18.647Z" },
 ]
 
 [[package]]
@@ -1925,15 +1923,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/14/d3/d6fa1cafdfa2b34dbfa304fc6833af8e1669fc34e24d214fa76d2a2e5a25/ty-0.0.27-py3-none-win32.whl", hash = "sha256:34e7377f2047c14dbbb7bf5322e84114db7a5f2cb470db6bee63f8f3550cfc1e", size = 9984415, upload-time = "2026-03-31T19:07:07.98Z" },
     { url = "https://files.pythonhosted.org/packages/85/e6/dd4e27da9632b3472d5711ca49dbd3709dbd3e8c73f3af6db9c254235ca9/ty-0.0.27-py3-none-win_amd64.whl", hash = "sha256:3f7e4145aad8b815ed69b324c93b5b773eb864dda366ca16ab8693ff88ce6f36", size = 10961535, upload-time = "2026-03-31T19:07:10.566Z" },
     { url = "https://files.pythonhosted.org/packages/0e/1a/824b3496d66852ed7d5d68d9787711131552b68dce8835ce9410db32e618/ty-0.0.27-py3-none-win_arm64.whl", hash = "sha256:95bf8d01eb96bb2ba3ffc39faff19da595176448e80871a7b362f4d2de58476c", size = 10376689, upload-time = "2026-03-31T19:07:25.732Z" },
-]
-
-[[package]]
-name = "types-stripe"
-version = "3.5.2.20240106"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/be/20/3f23987c2e4ee93e6d9a9ffd3058530d1e8373f5e134fd88b3f0ec5487eb/types-stripe-3.5.2.20240106.tar.gz", hash = "sha256:63a36958f0dc4a71685b027f0b6d807ff197ee337135ac19a0f8b6132365ca52", size = 19075, upload-time = "2024-01-06T02:21:44.89Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/73/a21fd4712675a4a0076f9260cdb193a339efbc4bf76fbe0d9a60dadd2b3f/types_stripe-3.5.2.20240106-py3-none-any.whl", hash = "sha256:9ea7bc9b9889a3d8606114c52dcc70a8fc62d44a46da4bc5ee19f0d463674bb8", size = 53986, upload-time = "2024-01-06T02:21:43.461Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The typeshed definitions for stripe haven't been updated for some time now - we can safely remove them and still get typehinting for the main functions.